### PR TITLE
fix: Include CSS config `at-rule-empty-line-before` options in SCSS config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # HEAD
 
 -   Added: `declaration-property-unit-whitelist` rule to enforce unitless `line-height` values.
--   Changed: Relocated repo to https://github.com/WordPress-Coding-Standards
+-   Changed: Relocated repo to https://github.com/WordPress-Coding-Standards.
+-   Fixed: Include CSS config `at-rule-empty-line-before` rules in SCSS config.
 
 # 10.0.2
 

--- a/__tests__/scss-invalid.scss
+++ b/__tests__/scss-invalid.scss
@@ -14,3 +14,10 @@ a {
 @else{
 	display: inline-block;
 }
+
+b {
+
+	@include foo;
+
+	@include bar;
+}

--- a/__tests__/scss-valid.scss
+++ b/__tests__/scss-valid.scss
@@ -24,3 +24,9 @@ $map: (
 
 @import "../some/url";
 @import "../another/url";
+
+b {
+
+	@include foo;
+	@include bar;
+}

--- a/__tests__/scss.js
+++ b/__tests__/scss.js
@@ -46,9 +46,9 @@ describe("flags warnings with invalid scss", () => {
     ))
   })
 
-  it("flags six warnings", () => {
+  it("flags seven warnings", () => {
     return result.then(data => (
-      expect(data.results[0].warnings.length).toBe(6)
+      expect(data.results[0].warnings.length).toBe(7)
     ))
   })
 
@@ -114,13 +114,13 @@ describe("flags warnings with invalid scss", () => {
 
   it("correct third warning text", () => {
     return result.then(data => (
-      expect(data.results[0].warnings[2].text).toBe("Expected single space before \"{\" (block-opening-brace-space-before)")
+      expect(data.results[0].warnings[2].text).toBe("Unexpected empty line before at-rule (at-rule-empty-line-before)")
     ))
   })
 
   it("correct third warning rule flagged", () => {
     return result.then(data => (
-      expect(data.results[0].warnings[2].rule).toBe("block-opening-brace-space-before")
+      expect(data.results[0].warnings[2].rule).toBe("at-rule-empty-line-before")
     ))
   })
 
@@ -132,101 +132,131 @@ describe("flags warnings with invalid scss", () => {
 
   it("correct third warning line number", () => {
     return result.then(data => (
-      expect(data.results[0].warnings[2].line).toBe(14)
+      expect(data.results[0].warnings[2].line).toBe(22)
     ))
   })
 
   it("correct third warning column number", () => {
     return result.then(data => (
-      expect(data.results[0].warnings[2].column).toBe(5)
+      expect(data.results[0].warnings[2].column).toBe(2)
     ))
   })
 
   it("correct forth warning text", () => {
     return result.then(data => (
-      expect(data.results[0].warnings[3].text).toBe("Unxpected empty line before @else (scss/at-else-empty-line-before)")
+      expect(data.results[0].warnings[2].text).toBe("Unexpected empty line before at-rule (at-rule-empty-line-before)")
     ))
   })
 
   it("correct forth warning rule flagged", () => {
     return result.then(data => (
-      expect(data.results[0].warnings[3].rule).toBe("scss/at-else-empty-line-before")
+      expect(data.results[0].warnings[2].rule).toBe("at-rule-empty-line-before")
     ))
   })
 
   it("correct forth warning severity flagged", () => {
     return result.then(data => (
-      expect(data.results[0].warnings[3].severity).toBe("error")
+      expect(data.results[0].warnings[2].severity).toBe("error")
     ))
   })
 
   it("correct forth warning line number", () => {
     return result.then(data => (
-      expect(data.results[0].warnings[3].line).toBe(14)
+      expect(data.results[0].warnings[2].line).toBe(22)
     ))
   })
 
   it("correct forth warning column number", () => {
     return result.then(data => (
-      expect(data.results[0].warnings[3].column).toBe(1)
+      expect(data.results[0].warnings[2].column).toBe(2)
     ))
   })
 
   it("correct fifth warning text", () => {
     return result.then(data => (
-      expect(data.results[0].warnings[4].text).toBe("Unexpected newline after \"}\" of @if statement (scss/at-if-closing-brace-newline-after)")
+      expect(data.results[0].warnings[3].text).toBe("Expected single space before \"{\" (block-opening-brace-space-before)")
     ))
   })
 
   it("correct fifth warning rule flagged", () => {
     return result.then(data => (
-      expect(data.results[0].warnings[4].rule).toBe("scss/at-if-closing-brace-newline-after")
+      expect(data.results[0].warnings[3].rule).toBe("block-opening-brace-space-before")
     ))
   })
 
   it("correct fifth warning severity flagged", () => {
     return result.then(data => (
-      expect(data.results[0].warnings[4].severity).toBe("error")
+      expect(data.results[0].warnings[3].severity).toBe("error")
     ))
   })
 
   it("correct fifth warning line number", () => {
     return result.then(data => (
-      expect(data.results[0].warnings[4].line).toBe(12)
+      expect(data.results[0].warnings[3].line).toBe(14)
     ))
   })
 
   it("correct fifth warning column number", () => {
     return result.then(data => (
-      expect(data.results[0].warnings[4].column).toBe(2)
+      expect(data.results[0].warnings[3].column).toBe(5)
     ))
   })
 
   it("correct sixth warning text", () => {
     return result.then(data => (
-      expect(data.results[0].warnings[5].text).toBe("Expected single space after \"}\" of @if statement (scss/at-if-closing-brace-space-after)")
+      expect(data.results[0].warnings[4].text).toBe("Unxpected empty line before @else (scss/at-else-empty-line-before)")
     ))
   })
 
   it("correct sixth warning rule flagged", () => {
     return result.then(data => (
-      expect(data.results[0].warnings[5].rule).toBe("scss/at-if-closing-brace-space-after")
+      expect(data.results[0].warnings[4].rule).toBe("scss/at-else-empty-line-before")
     ))
   })
 
   it("correct sixth warning severity flagged", () => {
     return result.then(data => (
-      expect(data.results[0].warnings[5].severity).toBe("error")
+      expect(data.results[0].warnings[4].severity).toBe("error")
     ))
   })
 
   it("correct sixth warning line number", () => {
     return result.then(data => (
-      expect(data.results[0].warnings[5].line).toBe(12)
+      expect(data.results[0].warnings[4].line).toBe(14)
     ))
   })
 
   it("correct sixth warning column number", () => {
+    return result.then(data => (
+      expect(data.results[0].warnings[4].column).toBe(1)
+    ))
+  })
+
+  it("correct seventh warning text", () => {
+    return result.then(data => (
+      expect(data.results[0].warnings[5].text).toBe("Unexpected newline after \"}\" of @if statement (scss/at-if-closing-brace-newline-after)")
+    ))
+  })
+
+  it("correct seventh warning rule flagged", () => {
+    return result.then(data => (
+      expect(data.results[0].warnings[5].rule).toBe("scss/at-if-closing-brace-newline-after")
+    ))
+  })
+
+  it("correct seventh warning severity flagged", () => {
+    return result.then(data => (
+      expect(data.results[0].warnings[5].severity).toBe("error")
+    ))
+  })
+
+  it("correct seventh warning line number", () => {
+    return result.then(data => (
+      expect(data.results[0].warnings[5].line).toBe(12)
+    ))
+  })
+
+  it("correct seventh warning column number", () => {
     return result.then(data => (
       expect(data.results[0].warnings[5].column).toBe(2)
     ))

--- a/scss.js
+++ b/scss.js
@@ -15,11 +15,12 @@ module.exports = {
     "at-rule-no-unknown": [ true, {
       ignoreAtRules: [ "extend", "at-root", "warn", "error", "if", "else", "for", "each", "while", "mixin", "include", "content", "return", "function" ],
     } ],
-    "at-rule-empty-line-before": [
-      "always", {
-        "ignoreAtRules": [ "else", "import" ],
-      },
-    ],
+    "at-rule-empty-line-before": [ "always", {
+      except: ["blockless-after-blockless"],
+      ignore: ["after-comment"],
+      ignoreAtRules: ["else"],
+    } ],
+
     "block-opening-brace-space-before": "always",
     "block-closing-brace-newline-after": [
       "always", {


### PR DESCRIPTION
This PR is a follow up to #131 to support all blockless _at-rules_ rather than just the `@import` rule