### PR TITLE
Fix: Allow `px` units in `line-height` values  for the `declaration-property-unit-whitelist` rule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HEAD
 
--   Added: `declaration-property-unit-whitelist` rule to enforce unitless `line-height` values.
+-   Added: `declaration-property-unit-whitelist` rule to allow `px` and exclude `%` and `em` units  in `line-height` values.
 -   Changed: Relocated repo to https://github.com/WordPress-Coding-Standards.
 -   Fixed: Include CSS config `at-rule-empty-line-before` rules in SCSS config.
 

--- a/__tests__/values-valid.css
+++ b/__tests__/values-valid.css
@@ -2,6 +2,7 @@
 	background-image: url(images/bg.png);
 	font-family: "Helvetica Neue", sans-serif;
 	font-weight: 700;
+	line-height: 14px;
 }
 
 .class { /* Correct usage of zero values */

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = {
     "declaration-colon-space-after": "always-single-line",
     "declaration-colon-space-before": "never",
     "declaration-property-unit-whitelist": {
-      "line-height": [],
+      "line-height": ["px"],
     },
     "font-family-name-quotes": "always-where-recommended",
     "font-weight-notation": [ "numeric", {


### PR DESCRIPTION
Follow up to #133, `px` units are allowed per the coding standards:

> https://make.wordpress.org/core/handbook/best-practices/coding-standards/css/#values
> _"Line height should also be unit-less, **unless necessary to be defined as a specific pixel value**. This is more than just a style convention, but is worth mentioning here."_