### PR TITLE
chore: Add a `dry-release` npm task

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "stylelint": "^7.10.1"
   },
   "scripts": {
+    "dry-release": "npmpub --dry --verbose",
     "lint:js": "eslint . --ignore-path .gitignore",
     "lint:md": "remark . --quiet --frail",
     "lint": "npm-run-all --parallel lint:*",


### PR DESCRIPTION
Adds a new `npm run dry-release` task to perform a "dry run" of the `npm run release` task