### PR TITLE
Use toHaveLength() in tests

### DIFF
--- a/__tests__/commenting.js
+++ b/__tests__/commenting.js
@@ -24,7 +24,7 @@ describe( 'flags no warnings with valid commenting css', () => {
 
 	it( 'flags no warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 0 )
+			expect( data.results[0].warnings ).toHaveLength( 0 )
 		) );
 	});
 });
@@ -47,7 +47,7 @@ describe( 'flags warnings with invalid commenting css', () => {
 
 	it( 'flags three warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 3 )
+			expect( data.results[0].warnings ).toHaveLength( 3 )
 		) );
 	});
 

--- a/__tests__/functions.js
+++ b/__tests__/functions.js
@@ -24,7 +24,7 @@ describe( 'flags no warnings with valid functions css', () => {
 
 	it( 'flags no warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 0 )
+			expect( data.results[0].warnings ).toHaveLength( 0 )
 		) );
 	});
 });
@@ -47,7 +47,7 @@ describe( 'flags warnings with invalid functions css', () => {
 
 	it( 'flags three warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 1 )
+			expect( data.results[0].warnings ).toHaveLength( 1 )
 		) );
 	});
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -24,7 +24,7 @@ describe( 'flags no warnings with valid css', () => {
 
 	it( 'flags no warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 0 )
+			expect( data.results[0].warnings ).toHaveLength( 0 )
 		) );
 	});
 });
@@ -47,7 +47,7 @@ describe( 'flags warnings with invalid css', () => {
 
 	it( 'flags one warning', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 1 )
+			expect( data.results[0].warnings ).toHaveLength( 1 )
 		) );
 	});
 

--- a/__tests__/media-queries.js
+++ b/__tests__/media-queries.js
@@ -24,7 +24,7 @@ describe( 'flags no warnings with valid media queries css', () => {
 
 	it( 'flags no warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 0 )
+			expect( data.results[0].warnings ).toHaveLength( 0 )
 		) );
 	});
 });
@@ -47,7 +47,7 @@ describe( 'flags warnings with invalid media queries css', () => {
 
 	it( 'flags ten warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 11 )
+			expect( data.results[0].warnings ).toHaveLength( 11 )
 		) );
 	});
 

--- a/__tests__/properties.js
+++ b/__tests__/properties.js
@@ -24,7 +24,7 @@ describe( 'flags no warnings with valid properties css', () => {
 
 	it( 'flags no warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 0 )
+			expect( data.results[0].warnings ).toHaveLength( 0 )
 		) );
 	});
 });
@@ -47,7 +47,7 @@ describe( 'flags warnings with invalid properties css', () => {
 
 	it( 'flags seven warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 7 )
+			expect( data.results[0].warnings ).toHaveLength( 7 )
 		) );
 	});
 

--- a/__tests__/scss.js
+++ b/__tests__/scss.js
@@ -24,7 +24,7 @@ describe( 'flags no warnings with valid scss', () => {
 
 	it( 'flags no warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 0 )
+			expect( data.results[0].warnings ).toHaveLength( 0 )
 		) );
 	});
 });
@@ -47,7 +47,7 @@ describe( 'flags warnings with invalid scss', () => {
 
 	it( 'flags seven warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 6 )
+			expect( data.results[0].warnings ).toHaveLength( 6 )
 		) );
 	});
 

--- a/__tests__/selectors-scss.js
+++ b/__tests__/selectors-scss.js
@@ -24,7 +24,7 @@ describe( 'flags no warnings with valid selectors scss', () => {
 
 	it( 'flags no warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 0 )
+			expect( data.results[0].warnings ).toHaveLength( 0 )
 		) );
 	});
 });
@@ -47,7 +47,7 @@ describe( 'flags warnings with invalid selectors scss', () => {
 
 	it( 'flags four warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 4 )
+			expect( data.results[0].warnings ).toHaveLength( 4 )
 		) );
 	});
 

--- a/__tests__/selectors.js
+++ b/__tests__/selectors.js
@@ -24,7 +24,7 @@ describe( 'flags no warnings with valid selectors css', () => {
 
 	it( 'flags no warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 0 )
+			expect( data.results[0].warnings ).toHaveLength( 0 )
 		) );
 	});
 });
@@ -47,7 +47,7 @@ describe( 'flags warnings with invalid selectors css', () => {
 
 	it( 'flags warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 3 )
+			expect( data.results[0].warnings ).toHaveLength( 3 )
 		) );
 	});
 

--- a/__tests__/structure.js
+++ b/__tests__/structure.js
@@ -24,7 +24,7 @@ describe( 'flags no warnings with valid structure css', () => {
 
 	it( 'flags no warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 0 )
+			expect( data.results[0].warnings ).toHaveLength( 0 )
 		) );
 	});
 });
@@ -47,7 +47,7 @@ describe( 'flags warnings with invalid structure css', () => {
 
 	it( 'flags eight warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 8 )
+			expect( data.results[0].warnings ).toHaveLength( 8 )
 		) );
 	});
 

--- a/__tests__/themes.js
+++ b/__tests__/themes.js
@@ -23,7 +23,7 @@ describe( 'flags no warnings with valid css', () => {
 
 	it( 'flags no warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 0 )
+			expect( data.results[0].warnings ).toHaveLength( 0 )
 		) );
 	});
 });

--- a/__tests__/values.js
+++ b/__tests__/values.js
@@ -24,7 +24,7 @@ describe( 'flags no warnings with valid values css', () => {
 
 	it( 'flags no warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 0 )
+			expect( data.results[0].warnings ).toHaveLength( 0 )
 		) );
 	});
 });
@@ -47,7 +47,7 @@ describe( 'flags warnings with invalid values css', () => {
 
 	it( 'flags warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 9 )
+			expect( data.results[0].warnings ).toHaveLength( 9 )
 		) );
 	});
 

--- a/__tests__/vendor-prefixes.js
+++ b/__tests__/vendor-prefixes.js
@@ -23,7 +23,7 @@ describe( 'flags no warnings with valid vendor prefixes css', () => {
 
 	it( 'flags no warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings.length ).toBe( 0 )
+			expect( data.results[0].warnings ).toHaveLength( 0 )
 		) );
 	});
 });


### PR DESCRIPTION
Not only does it check the length of something is exactly a certain integer, it also checks that the length property exists in the first place.

Addresses lint issues identified at https://www.bithound.io/github/WordPress-Coding-Standards/stylelint-config-wordpress/e2bbe0d9c867cc95da6de5b3bff2a73742135fb6/files#failing

See https://facebook.github.io/jest/docs/en/expect.html#tohavelengthnumber