### PR TITLE
Update `selector-pseudo-element-colon-notation` to use `double`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 -   Changed: Improved `no-duplicate-selectors` tests.
 -   Removed: Jest snapshots.
 -   Removed: `stylelint < 9.1.3` compatibility.
+-   Updated: `selector-pseudo-element-colon-notation` to use `double`
 -   Updated: `stylelint-config-recommended` to `2.1.0`.
 -   Updated: `stylelint-scss` to `2.1.0`.
 -   Updated: Bump minimum Node.js required version to `8.9.3`.

--- a/__tests__/selectors-invalid.css
+++ b/__tests__/selectors-invalid.css
@@ -25,3 +25,7 @@ input[type='text'] { /* Should be [type="text"] */
 .selectorA {
 	color: #000;
 }
+
+.selector:after {
+	color: #000;
+}

--- a/__tests__/selectors-invalid.scss
+++ b/__tests__/selectors-invalid.scss
@@ -25,3 +25,10 @@ p {
 		margin: 0;
 	}
 }
+
+span {
+
+	& .class:after {
+		margin: 0;
+	}
+}

--- a/__tests__/selectors-scss.test.js
+++ b/__tests__/selectors-scss.test.js
@@ -45,9 +45,9 @@ describe( 'flags warnings with invalid selectors scss', () => {
 		) );
 	});
 
-	it( 'flags four warnings', () => {
+	it( 'flags six warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings ).toHaveLength( 4 )
+			expect( data.results[0].warnings ).toHaveLength( 6 )
 		) );
 	});
 

--- a/__tests__/selectors-valid.css
+++ b/__tests__/selectors-valid.css
@@ -5,3 +5,7 @@
 input[type="text"] {
 	line-height: 1.1;
 }
+
+.selector::after {
+	color: #000;
+}

--- a/__tests__/selectors-valid.scss
+++ b/__tests__/selectors-valid.scss
@@ -27,3 +27,11 @@ p {
 		margin: 0;
 	}
 }
+
+span {
+
+	&,
+	.foo::after {
+		color: #000;
+	}
+}

--- a/__tests__/selectors.test.js
+++ b/__tests__/selectors.test.js
@@ -47,7 +47,7 @@ describe( 'flags warnings with invalid selectors css', () => {
 
 	it( 'flags warnings', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings ).toHaveLength( 3 )
+			expect( data.results[0].warnings ).toHaveLength( 4 )
 		) );
 	});
 
@@ -113,13 +113,13 @@ describe( 'flags warnings with invalid selectors css', () => {
 
 	it( 'correct third warning text', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings[2].text ).toBe( 'Expected double quotes (string-quotes)' )
+			expect( data.results[0].warnings[2].text ).toBe( 'Expected double colon pseudo-element notation (selector-pseudo-element-colon-notation)' )
 		) );
 	});
 
 	it( 'correct third warning rule flagged', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings[2].rule ).toBe( 'string-quotes' )
+			expect( data.results[0].warnings[2].rule ).toBe( 'selector-pseudo-element-colon-notation' )
 		) );
 	});
 
@@ -131,13 +131,43 @@ describe( 'flags warnings with invalid selectors css', () => {
 
 	it( 'correct third warning line number', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings[2].line ).toBe( 17 )
+			expect( data.results[0].warnings[2].line ).toBe( 29 )
 		) );
 	});
 
 	it( 'correct third warning column number', () => {
 		return result.then( data => (
-			expect( data.results[0].warnings[2].column ).toBe( 12 )
+			expect( data.results[0].warnings[2].column ).toBe( 10 )
+		) );
+	});
+
+	it( 'correct fourth warning text', () => {
+		return result.then( data => (
+			expect( data.results[0].warnings[3].text ).toBe( 'Expected double quotes (string-quotes)' )
+		) );
+	});
+
+	it( 'correct fourth warning rule flagged', () => {
+		return result.then( data => (
+			expect( data.results[0].warnings[3].rule ).toBe( 'string-quotes' )
+		) );
+	});
+
+	it( 'correct fourth warning severity flagged', () => {
+		return result.then( data => (
+			expect( data.results[0].warnings[3].severity ).toBe( 'error' )
+		) );
+	});
+
+	it( 'correct fourth warning line number', () => {
+		return result.then( data => (
+			expect( data.results[0].warnings[3].line ).toBe( 17 )
+		) );
+	});
+
+	it( 'correct fourth warning column number', () => {
+		return result.then( data => (
+			expect( data.results[0].warnings[3].column ).toBe( 12 )
 		) );
 	});
 });

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ module.exports = {
 		'selector-pseudo-class-case': 'lower',
 		'selector-pseudo-class-parentheses-space-inside': 'never',
 		'selector-pseudo-element-case': 'lower',
-		'selector-pseudo-element-colon-notation': 'single',
+		'selector-pseudo-element-colon-notation': 'double',
 		'selector-type-case': 'lower',
 		'string-quotes': 'double',
 		'unit-case': 'lower',


### PR DESCRIPTION
Closes #174 