### PR TITLE
chore: update `stylelint-config-recommended-scss` to v3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 	"main": "index.js",
 	"dependencies": {
 		"stylelint-config-recommended": "^2.2.0",
-		"stylelint-config-recommended-scss": "^3.2.0",
+		"stylelint-config-recommended-scss": "^3.3.0",
 		"stylelint-scss": "^3.6.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
`warning "stylelint-config-wordpress > stylelint-config-recommended-scss@3.2.0" has incorrect peer dependency "stylelint@^8.3.0 || ^9.0.0".`