### PR TITLE
fix: rename deprecated `declaration-property-unit-whitelist` rule

### DIFF
--- a/__tests__/__snapshots__/selectors.test.js.snap
+++ b/__tests__/__snapshots__/selectors.test.js.snap
@@ -5,9 +5,9 @@ Array [
   Object {
     "column": 15,
     "line": 18,
-    "rule": "declaration-property-unit-whitelist",
+    "rule": "declaration-property-unit-allowed-list",
     "severity": "error",
-    "text": "Unexpected unit \\"%\\" for property \\"line-height\\" (declaration-property-unit-whitelist)",
+    "text": "Unexpected unit \\"%\\" for property \\"line-height\\" (declaration-property-unit-allowed-list)",
   },
   Object {
     "column": 1,

--- a/__tests__/__snapshots__/values.test.js.snap
+++ b/__tests__/__snapshots__/values.test.js.snap
@@ -19,9 +19,9 @@ Array [
   Object {
     "column": 15,
     "line": 12,
-    "rule": "declaration-property-unit-whitelist",
+    "rule": "declaration-property-unit-allowed-list",
     "severity": "error",
-    "text": "Unexpected unit \\"em\\" for property \\"line-height\\" (declaration-property-unit-whitelist)",
+    "text": "Unexpected unit \\"em\\" for property \\"line-height\\" (declaration-property-unit-allowed-list)",
   },
   Object {
     "column": 15,

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = {
 		'declaration-colon-newline-after': 'always-multi-line',
 		'declaration-colon-space-after': 'always-single-line',
 		'declaration-colon-space-before': 'never',
-		'declaration-property-unit-whitelist': {
+		'declaration-property-unit-allowed-list': {
 			'line-height': [ 'px' ],
 		},
 		'font-family-name-quotes': 'always-where-recommended',


### PR DESCRIPTION
The rule `declaration-property-unit-whitelist` has been deprecated in stylelint 13.7.0 and renamed to `declaration-property-unit-allowed-list`

https://github.com/stylelint/stylelint/blob/13.7.0/lib/rules/declaration-property-unit-whitelist/README.md

This fixes #266 